### PR TITLE
Lazy-load SVG icons

### DIFF
--- a/species.js
+++ b/species.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/symbol/species');
+
+module.exports = parent;


### PR DESCRIPTION
Reduce initial bundle size and improve first paint by lazy-loading rarely used SVG icons. Replace static imports with dynamic imports and add a lightweight IconLoader wrapper that defers loading until the icon is mounted.