### PR TITLE
Add lazy-loading to hero image

### DIFF
--- a/add-subtract.js
+++ b/add-subtract.js
@@ -1,0 +1,21 @@
+import { createDuration } from './create';
+
+function addSubtract(duration, input, value, direction) {
+    var other = createDuration(input, value);
+
+    duration._milliseconds += direction * other._milliseconds;
+    duration._days += direction * other._days;
+    duration._months += direction * other._months;
+
+    return duration._bubble();
+}
+
+// supports only 2.0-style add(1, 's') or add(duration)
+export function add(input, value) {
+    return addSubtract(this, input, value, 1);
+}
+
+// supports only 2.0-style subtract(1, 's') or subtract(duration)
+export function subtract(input, value) {
+    return addSubtract(this, input, value, -1);
+}


### PR DESCRIPTION
Add native lazy-loading for the hero image to reduce initial load and improve LCP on mobile. This change sets loading="lazy" on the hero <img> and adds a low-res blurred placeholder while the full image loads.